### PR TITLE
Support for muting and unmuting monitors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+Version 0.2.0
+
+  - add support to mute and unmute monitors by id, name or regex
+
 Version 0.1.1
 
   - add ``message`` and ``escalation_message`` options to ``DogTrainer::API.upsert_monitor``

--- a/README.md
+++ b/README.md
@@ -164,6 +164,54 @@ dog.upsert_monitor(
 )
 ```
 
+##### Muting and Unmuting monitors
+
+Mute a single monitor by ID number (12345):
+
+```ruby
+dog.mute_monitor_by_id(12345)
+```
+
+Mute a single monitor by ID number (12345) for one hour:
+
+```ruby
+ts = Time.now + 3600
+dog.mute_monitor_by_id(12345, end_timestamp: ts.to_i)
+```
+
+Unmute a single monitor by ID number (12345):
+
+```ruby
+dog.unmute_monitor_by_id(12345)
+```
+
+Mute a single monitor by name for one hour:
+
+```ruby
+ts = Time.now + 3600
+dog.mute_monitor_by_name('my whole monitor name', end_timestamp: ts.to_i)
+```
+
+Unmute a single monitor by name:
+
+```ruby
+dog.unmute_monitor_by_name('my whole monitor name')
+```
+
+Mute all monitors matching regex /ELB/ for one hour (this also accepts a String
+  in addition to Regexp objects):
+
+```ruby
+ts = Time.now + 3600
+dog.mute_monitor_by_regex(/ELB/, end_timestamp: ts.to_i)
+```
+
+Unmute all monitors matching /foo/ (provided as a String instead of Regexp):
+
+```ruby
+dog.unmute_monitor_by_regex('foo')
+```
+
 #### Boards
 
 Create a TimeBoard with a handful of graphs about the "MY_ELB_NAME" ELB,

--- a/README.md
+++ b/README.md
@@ -203,13 +203,13 @@ Mute all monitors matching regex /ELB/ for one hour (this also accepts a String
 
 ```ruby
 ts = Time.now + 3600
-dog.mute_monitor_by_regex(/ELB/, end_timestamp: ts.to_i)
+dog.mute_monitors_by_regex(/ELB/, end_timestamp: ts.to_i)
 ```
 
 Unmute all monitors matching /foo/ (provided as a String instead of Regexp):
 
 ```ruby
-dog.unmute_monitor_by_regex('foo')
+dog.unmute_monitors_by_regex('foo')
 ```
 
 #### Boards

--- a/lib/dogtrainer/api.rb
+++ b/lib/dogtrainer/api.rb
@@ -354,7 +354,7 @@ module DogTrainer
     #
     # @param mon_id [Integer] ID of the monitor to mute
     # @param [Hash] options
-    # @option options [Integer] or [Fixnum] :end_timestamp optional timestamp
+    # @option options [Integer] :end_timestamp optional timestamp
     #  for when the mute should end; Integer POSIX timestamp.
     def mute_monitor_by_id(mon_id, options = { end_timestamp: nil })
       if options.fetch(:end_timestamp, nil).nil?
@@ -380,7 +380,7 @@ module DogTrainer
     #
     # @param mon_name [String] name of the monitor to mute
     # @param [Hash] options
-    # @option options [Integer] or [Fixnum] :end_timestamp optional timestamp
+    # @option options [Integer] :end_timestamp optional timestamp
     #  for when the mute should end; Integer POSIX timestamp.
     # @raise [RuntimeError] raised if the specified monitor name can't be found
     def mute_monitor_by_name(mon_name, options = { end_timestamp: nil })
@@ -416,7 +416,7 @@ module DogTrainer
     # @param mon_name_regex [String] or [Regexp] regex to match monitor names
     #   against
     # @param [Hash] options
-    # @option options [Integer] or [Fixnum] :end_timestamp optional timestamp
+    # @option options [Integer] :end_timestamp optional timestamp
     #  for when the mute should end; Integer POSIX timestamp.
     def mute_monitors_by_regex(mon_name_regex, options = { end_timestamp: nil })
       if mon_name_regex.class != Regexp

--- a/lib/dogtrainer/api.rb
+++ b/lib/dogtrainer/api.rb
@@ -322,19 +322,157 @@ module DogTrainer
     #
     # @param mon_name [String] name of the monitor to return
     def get_existing_monitor_by_name(mon_name)
-      if @monitors.nil?
-        @monitors = @dog.get_all_monitors(group_states: 'all')
-        logger.info "Found #{@monitors[1].length} existing monitors in DataDog"
-        if @monitors[1].empty?
-          logger.error 'ERROR: Docker API call returned no existing monitors.' \
-            ' Something is wrong.'
-          exit 1
-        end
-      end
-      @monitors[1].each do |mon|
+      get_monitors.each do |mon|
         return mon if mon['name'] == mon_name
       end
       nil
+    end
+
+    # Get all monitors from DataDog, caching them in an instance variable.
+    def get_monitors
+      if @monitors.nil?
+        @monitors = @dog.get_all_monitors(group_states: 'all')
+        logger.info "Found #{@monitors[1].length} existing monitors in DataDog"
+        if @monitors[1].length < 1
+          raise RuntimeError, 'ERROR: DataDog API call returned no existing ' \
+            'monitors. Something is wrong.'
+        end
+      end
+      @monitors[1]
+    end
+
+    # Mute the monitor identified by the specified unique ID, with an optional
+    # duration.
+    #
+    # @example mute monitor 12345 indefinitely
+    #    dog = DogTrainer::API.new(api_key, app_key, notify_to)
+    #    dog.mute_monitor_by_id(12345)
+    #
+    # @example mute monitor 12345 until 2016-09-17 01:39:52-00:00
+    #    dog = DogTrainer::API.new(api_key, app_key, notify_to)
+    #    dog.mute_monitor_by_id(12345, end_timestamp: 1474076393)
+    #
+    # @param mon_id [Integer] ID of the monitor to mute
+    # @param [Hash] options
+    # @option options [Integer] or [Fixnum] :end_timestamp optional timestamp
+    #  for when the mute should end; Integer POSIX timestamp.
+    def mute_monitor_by_id(mon_id, options = {end_timestamp: nil})
+      if options.fetch(:end_timestamp, nil).nil?
+        logger.info "Muting monitor by ID #{mon_id}"
+        @dog.mute_monitor(mon_id)
+      else
+        end_ts = options[:end_timestamp]
+        logger.info "Muting monitor by ID #{mon_id} until #{end_ts}"
+        @dog.mute_monitor(mon_id, end: end_ts)
+      end
+    end
+
+    # Mute the monitor identified by the specified name, with an optional
+    # duration.
+    #
+    # @example mute monitor named 'My Monitor' indefinitely
+    #    dog = DogTrainer::API.new(api_key, app_key, notify_to)
+    #    dog.mute_monitor_by_name('My Monitor')
+    #
+    # @example mute monitor named 'My Monitor' until 2016-09-17 01:39:52-00:00
+    #    dog = DogTrainer::API.new(api_key, app_key, notify_to)
+    #    dog.mute_monitor_by_name('My Monitor', end_timestamp: 1474076393)
+    #
+    # @param mon_name [String] name of the monitor to mute
+    # @param [Hash] options
+    # @option options [Integer] or [Fixnum] :end_timestamp optional timestamp
+    #  for when the mute should end; Integer POSIX timestamp.
+    # @raise [RuntimeError] raised if the specified monitor name can't be found
+    def mute_monitor_by_name(mon_name, options = {end_timestamp: nil})
+      mon = get_existing_monitor_by_name(mon_name)
+      if mon.nil?
+        raise RuntimeError, "ERROR: Could not find monitor with name #{mon_name}"
+      end
+      if options.fetch(:end_timestamp, nil).nil?
+        logger.info "Muting monitor by name #{mon_name} (#{mon['id']})"
+        @dog.mute_monitor(mon['id'])
+      else
+        end_ts = options[:end_timestamp]
+        logger.info "Muting monitor by name #{mon_name} (#{mon['id']}) until #{end_ts}"
+        @dog.mute_monitor(mon['id'], end: end_ts)
+      end
+    end
+
+    # Mute all monitors with names matching the specified regex, with an optional
+    # duration
+    #
+    # @example mute monitors with names matching /myapp/ indefinitely
+    #    dog = DogTrainer::API.new(api_key, app_key, notify_to)
+    #    dog.mute_monitor_by_regex(/myapp/)
+    #
+    # @example mute monitors with names containing 'foo' indefinitely
+    #    dog = DogTrainer::API.new(api_key, app_key, notify_to)
+    #    dog.mute_monitor_by_regex('foo')
+    #
+    # @example mute monitors with names matching /myapp/ until 2016-09-17 01:39:52-00:00
+    #    dog = DogTrainer::API.new(api_key, app_key, notify_to)
+    #    dog.mute_monitor_by_regex(/myapp/, end_timestamp: 1474076393)
+    #
+    # @param mon_name_regex [String] or [Regexp] regex to match monitor names against
+    # @param [Hash] options
+    # @option options [Integer] or [Fixnum] :end_timestamp optional timestamp
+    #  for when the mute should end; Integer POSIX timestamp.
+    def mute_monitors_by_regex(mon_name_regex, options = {end_timestamp: nil})
+      if mon_name_regex.class != Regexp
+        mon_name_regex = Regexp.new(mon_name_regex)
+      end
+      if options.fetch(:end_timestamp, nil).nil?
+        logger.info "Muting monitors by regex #{mon_name_regex.source}"
+        end_ts = nil
+      else
+        logger.info "Muting monitors by regex #{mon_name_regex.source} until #{end_ts}"
+        end_ts = options[:end_timestamp]
+      end
+      logger.debug "Searching for monitors matching: #{mon_name_regex.source}"
+      get_monitors.each do |mon|
+        #puts "MONITOR: #{mon['name']} (#{mon['id']})"
+        if mon['name'] =~ mon_name_regex
+          logger.info "Muting monitor '#{mon['name']}' (#{mon['id']})"
+          mute_monitor_by_id(mon['id'], end_timestamp: end_ts)
+        end
+      end
+    end
+
+    # Unute the monitor identified by the specified unique ID.
+    #
+    # @param mon_id [Integer] ID of the monitor to mute
+    def unmute_monitor_by_id(mon_id)
+      logger.info "Unmuting monitor by ID #{mon_id}"
+      @dog.unmute_monitor(mon_id, all_scopes: true)
+    end
+
+    # Unmute the monitor identified by the specified name.
+    #
+    # @param mon_name [String] name of the monitor to mute
+    # @raise [RuntimeError] raised if the specified monitor name can't be found
+    def unmute_monitor_by_name(mon_name)
+      mon = get_existing_monitor_by_name(mon_name)
+      logger.info "Unmuting monitor by name #{mon_name}"
+      if mon.nil?
+        raise RuntimeError, "ERROR: Could not find monitor with name #{mon_name}"
+      end
+      unmute_monitor_by_id(mon['id'])
+    end
+
+    # Unmute all monitors with names matching the specified regex.
+    #
+    # @param mon_name_regex [String] regex to match monitor names against
+    def unmute_monitors_by_regex(mon_name_regex)
+      if mon_name_regex.class != Regexp
+        mon_name_regex = Regexp.new(mon_name_regex)
+      end
+      logger.info "Unmuting monitors by regex #{mon_name_regex.source}"
+      get_monitors.each do |mon|
+        if mon['name'] =~ mon_name_regex
+          logger.info "Unmuting monitor '#{mon['name']}' (#{mon['id']})"
+          unmute_monitor_by_id(mon['id'])
+        end
+      end
     end
 
     ###########################################

--- a/lib/dogtrainer/version.rb
+++ b/lib/dogtrainer/version.rb
@@ -1,4 +1,4 @@
 module DogTrainer
   # store the verson of the Gem/module; used in the gemspec and in messages
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -948,7 +948,7 @@ describe DogTrainer::API do
       expect(subject.create_monitor('foo', params)).to be_nil
     end
   end
-  describe '#get_existing_monitor_by_name' do
+  describe '#get_monitors' do
     it 'retrieves monitors if they are not cached' do
       monitors = [
         '200',
@@ -963,8 +963,7 @@ describe DogTrainer::API do
       subject.instance_variable_set('@dog', dog)
 
       expect(dog).to receive(:get_all_monitors).once.with(group_states: 'all')
-      expect(subject.get_existing_monitor_by_name('bar'))
-        .to eq('name' => 'bar', 'foo' => 'baz')
+      expect(subject.get_monitors()).to eq(monitors[1])
       expect(subject.instance_variable_get('@monitors')).to eq(monitors)
     end
     it 'does not retrieve monitors if they are cached' do
@@ -982,25 +981,257 @@ describe DogTrainer::API do
       subject.instance_variable_set('@monitors', monitors)
 
       expect(dog).to_not receive(:get_all_monitors)
-      expect(subject.get_existing_monitor_by_name('bar'))
-        .to eq('name' => 'bar', 'foo' => 'baz')
+      expect(subject.get_monitors()).to eq(monitors[1])
       expect(subject.instance_variable_get('@monitors')).to eq(monitors)
     end
-    it 'exits if no monitors can be found' do
-      monitors = ['200', []]
+    it 'raises if monitors list is empty' do
+      monitors = [ '200', [] ]
       dog = double(Dogapi::Client)
       allow(dog).to receive(:get_all_monitors).with(any_args)
         .and_return(monitors)
       subject.instance_variable_set('@dog', dog)
-      allow(subject.logger).to receive(:error).with(any_args)
 
-      expect(dog).to receive(:get_all_monitors).once
-        .with(group_states: 'all')
-      expect(subject.logger).to receive(:error).once
-        .with('ERROR: Docker API call returned no existing monitors. ' \
-          'Something is wrong.')
-      expect { subject.get_existing_monitor_by_name('bar') }
-        .to raise_error(SystemExit)
+      expect(dog).to receive(:get_all_monitors).once.with(group_states: 'all')
+      expect {subject.get_monitors() }
+        .to raise_error(RuntimeError, 'ERROR: DataDog API call returned no ' \
+          'existing monitors. Something is wrong.')
+    end
+  end
+  describe '#mute_monitor_by_id' do
+    it 'calls dog.mute_monitor with id' do
+      dog = double(Dogapi::Client)
+      allow(dog).to receive(:mute_monitor).with(any_args)
+      subject.instance_variable_set('@dog', dog)
+
+      expect(dog).to receive(:mute_monitor).once.with(12345)
+      subject.mute_monitor_by_id(12345)
+    end
+    it 'calls dog.mute_monitor with id and timestamp if specified' do
+      dog = double(Dogapi::Client)
+      allow(dog).to receive(:mute_monitor).with(any_args)
+      subject.instance_variable_set('@dog', dog)
+
+      expect(dog).to receive(:mute_monitor).once
+        .with(12345, {end: 6789})
+      subject.mute_monitor_by_id(12345, end_timestamp: 6789)
+    end
+  end
+  describe '#mute_monitor_by_name' do
+    it 'calls dog.mute_monitor with id' do
+      monitor = {
+        'id' => 5678,
+      }
+      dog = double(Dogapi::Client)
+      allow(dog).to receive(:mute_monitor).with(any_args)
+      allow(subject).to receive(:get_existing_monitor_by_name)
+        .and_return(monitor)
+      subject.instance_variable_set('@dog', dog)
+
+      expect(subject).to receive(:get_existing_monitor_by_name).once
+        .with('mymon')
+      expect(dog).to receive(:mute_monitor).once.with(5678)
+      subject.mute_monitor_by_name('mymon')
+    end
+    it 'calls dog.mute_monitor with id and timestamp if specified' do
+      monitor = {
+        'id' => 5678,
+      }
+      dog = double(Dogapi::Client)
+      allow(dog).to receive(:mute_monitor).with(any_args)
+      allow(subject).to receive(:get_existing_monitor_by_name)
+        .and_return(monitor)
+      subject.instance_variable_set('@dog', dog)
+
+      expect(subject).to receive(:get_existing_monitor_by_name).once
+        .with('mymon')
+      expect(dog).to receive(:mute_monitor).once.with(5678, {end: 1234})
+      subject.mute_monitor_by_name('mymon', end_timestamp: 1234)
+    end
+    it 'raises error if monitor cannot be found' do
+      dog = double(Dogapi::Client)
+      allow(dog).to receive(:mute_monitor).with(any_args)
+      allow(subject).to receive(:get_existing_monitor_by_name)
+        .and_return(nil)
+      subject.instance_variable_set('@dog', dog)
+
+      expect(subject).to receive(:get_existing_monitor_by_name).once
+        .with('mymon')
+      expect(dog).to_not receive(:mute_monitor)
+      expect { subject.mute_monitor_by_name('mymon') }
+        .to raise_error(RuntimeError,
+                        'ERROR: Could not find monitor with name mymon')
+    end
+  end
+  describe '#mute_monitors_by_regex' do
+    it 'mutes all matching monitors when passed a regex' do
+      monitors = [
+        {'name' => 'mymonitor', 'id' => 1},
+        {'name' => 'foo', 'id' => 2},
+        {'name' => 'bar', 'id' => 3},
+        {'name' => 'other monitor foo', 'id' => 4}
+      ]
+      allow(subject).to receive(:get_monitors).and_return(monitors)
+      allow(subject).to receive(:mute_monitor_by_id)
+
+      expect(subject).to receive(:get_monitors).once
+      expect(subject).to receive(:mute_monitor_by_id).once
+        .with(1, end_timestamp: nil)
+      expect(subject).to receive(:mute_monitor_by_id).once
+        .with(4, end_timestamp: nil)
+      subject.mute_monitors_by_regex(/monitor/)
+    end
+    it 'mutes all matching monitors when passed a string' do
+      monitors = [
+        {'name' => 'mymonitor', 'id' => 1},
+        {'name' => 'foo', 'id' => 2},
+        {'name' => 'bar', 'id' => 3},
+        {'name' => 'other monitor foo', 'id' => 4}
+      ]
+      allow(subject).to receive(:get_monitors).and_return(monitors)
+      allow(subject).to receive(:mute_monitor_by_id)
+
+      expect(subject).to receive(:get_monitors).once
+      expect(subject).to receive(:mute_monitor_by_id).once
+        .with(1, end_timestamp: nil)
+      expect(subject).to receive(:mute_monitor_by_id).once
+        .with(4, end_timestamp: nil)
+      subject.mute_monitors_by_regex('monitor')
+    end
+    it 'mutes all monitors with an end_timestamp if specified' do
+      monitors = [
+        {'name' => 'mymonitor', 'id' => 1},
+        {'name' => 'foo', 'id' => 2},
+        {'name' => 'bar', 'id' => 3},
+        {'name' => 'other monitor foo', 'id' => 4}
+      ]
+      allow(subject).to receive(:get_monitors).and_return(monitors)
+      allow(subject).to receive(:mute_monitor_by_id)
+
+      expect(subject).to receive(:get_monitors).once
+      expect(subject).to receive(:mute_monitor_by_id).once
+        .with(1, end_timestamp: 1234)
+      expect(subject).to receive(:mute_monitor_by_id).once
+        .with(4, end_timestamp: 1234)
+      subject.mute_monitors_by_regex('monitor', end_timestamp: 1234)
+    end
+    it 'does not mute any monitors if there are no matches' do
+      monitors = [
+        {'name' => 'foo', 'id' => 2},
+        {'name' => 'bar', 'id' => 3}
+      ]
+      allow(subject).to receive(:get_monitors).and_return(monitors)
+      allow(subject).to receive(:mute_monitor_by_id)
+
+      expect(subject).to receive(:get_monitors).once
+      expect(subject).to_not receive(:mute_monitor_by_id)
+      subject.mute_monitors_by_regex('monitor')
+    end
+  end
+  describe '#unmute_monitor_by_id' do
+    it 'calls dog.unmute_monitor with id' do
+      dog = double(Dogapi::Client)
+      allow(dog).to receive(:unmute_monitor).with(any_args)
+      subject.instance_variable_set('@dog', dog)
+
+      expect(dog).to receive(:unmute_monitor).once
+        .with(12345, {:all_scopes=>true})
+      subject.unmute_monitor_by_id(12345)
+    end
+  end
+  describe '#unmute_monitor_by_name' do
+    it 'calls dog.unmute_monitor with id' do
+      monitor = {
+        'id' => 5678,
+      }
+      allow(subject).to receive(:unmute_monitor_by_id).with(any_args)
+      allow(subject).to receive(:get_existing_monitor_by_name)
+        .and_return(monitor)
+
+      expect(subject).to receive(:get_existing_monitor_by_name).once
+        .with('mymon')
+      expect(subject).to receive(:unmute_monitor_by_id).once
+        .with(5678)
+      subject.unmute_monitor_by_name('mymon')
+    end
+    it 'raises error if monitor cannot be found' do
+      allow(subject).to receive(:unmute_monitor_by_id).with(any_args)
+      allow(subject).to receive(:get_existing_monitor_by_name)
+        .and_return(nil)
+
+      expect(subject).to receive(:get_existing_monitor_by_name).once
+        .with('mymon')
+      expect(subject).to_not receive(:unmute_monitor_by_id)
+      expect { subject.unmute_monitor_by_name('mymon') }
+        .to raise_error(RuntimeError,
+                        'ERROR: Could not find monitor with name mymon')
+    end
+  end
+  describe '#unmute_monitors_by_regex' do
+    it 'unmutes all matching monitors when passed a regex' do
+      monitors = [
+        {'name' => 'mymonitor', 'id' => 1},
+        {'name' => 'foo', 'id' => 2},
+        {'name' => 'bar', 'id' => 3},
+        {'name' => 'other monitor foo', 'id' => 4}
+      ]
+      allow(subject).to receive(:get_monitors).and_return(monitors)
+      allow(subject).to receive(:unmute_monitor_by_id)
+
+      expect(subject).to receive(:get_monitors).once
+      expect(subject).to receive(:unmute_monitor_by_id).once.with(1)
+      expect(subject).to receive(:unmute_monitor_by_id).once.with(4)
+      subject.unmute_monitors_by_regex(/monitor/)
+    end
+    it 'unmutes all matching monitors when passed a string' do
+      monitors = [
+        {'name' => 'mymonitor', 'id' => 1},
+        {'name' => 'foo', 'id' => 2},
+        {'name' => 'bar', 'id' => 3},
+        {'name' => 'other monitor foo', 'id' => 4}
+      ]
+      allow(subject).to receive(:get_monitors).and_return(monitors)
+      allow(subject).to receive(:unmute_monitor_by_id)
+
+      expect(subject).to receive(:get_monitors).once
+      expect(subject).to receive(:unmute_monitor_by_id).once.with(1)
+      expect(subject).to receive(:unmute_monitor_by_id).once.with(4)
+      subject.unmute_monitors_by_regex('monitor')
+    end
+    it 'does not unmute any monitors if there are no matches' do
+      monitors = [
+        {'name' => 'foo', 'id' => 2},
+        {'name' => 'bar', 'id' => 3}
+      ]
+      allow(subject).to receive(:get_monitors).and_return(monitors)
+      allow(subject).to receive(:unmute_monitor_by_id)
+
+      expect(subject).to receive(:get_monitors).once
+      expect(subject).to_not receive(:unmute_monitor_by_id)
+      subject.unmute_monitors_by_regex('monitor')
+    end
+  end
+  describe '#get_existing_monitor_by_name' do
+    it 'returns the monitor if it exists' do
+      monitors = [
+        '200',
+        [
+          { 'name' => 'foo', 'foo' => 'bar' },
+          { 'name' => 'bar', 'foo' => 'baz' }
+        ]
+      ]
+      allow(subject).to receive(:get_monitors).and_return(monitors[1])
+
+      expect(subject).to receive(:get_monitors).once
+      expect(subject.get_existing_monitor_by_name('bar'))
+        .to eq('name' => 'bar', 'foo' => 'baz')
+    end
+    it 'returns nil if no monitors can be found' do
+      monitors = ['200', []]
+      dog = double(Dogapi::Client)
+      allow(subject).to receive(:get_monitors).and_return(monitors[1])
+
+      expect(subject).to receive(:get_monitors).once
+      expect(subject.get_existing_monitor_by_name('bar')).to be_nil
     end
   end
   describe '#graphdef' do

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -963,7 +963,7 @@ describe DogTrainer::API do
       subject.instance_variable_set('@dog', dog)
 
       expect(dog).to receive(:get_all_monitors).once.with(group_states: 'all')
-      expect(subject.get_monitors()).to eq(monitors[1])
+      expect(subject.get_monitors).to eq(monitors[1])
       expect(subject.instance_variable_get('@monitors')).to eq(monitors)
     end
     it 'does not retrieve monitors if they are cached' do
@@ -981,18 +981,18 @@ describe DogTrainer::API do
       subject.instance_variable_set('@monitors', monitors)
 
       expect(dog).to_not receive(:get_all_monitors)
-      expect(subject.get_monitors()).to eq(monitors[1])
+      expect(subject.get_monitors).to eq(monitors[1])
       expect(subject.instance_variable_get('@monitors')).to eq(monitors)
     end
     it 'raises if monitors list is empty' do
-      monitors = [ '200', [] ]
+      monitors = ['200', []]
       dog = double(Dogapi::Client)
       allow(dog).to receive(:get_all_monitors).with(any_args)
         .and_return(monitors)
       subject.instance_variable_set('@dog', dog)
 
       expect(dog).to receive(:get_all_monitors).once.with(group_states: 'all')
-      expect {subject.get_monitors() }
+      expect { subject.get_monitors }
         .to raise_error(RuntimeError, 'ERROR: DataDog API call returned no ' \
           'existing monitors. Something is wrong.')
     end
@@ -1003,8 +1003,8 @@ describe DogTrainer::API do
       allow(dog).to receive(:mute_monitor).with(any_args)
       subject.instance_variable_set('@dog', dog)
 
-      expect(dog).to receive(:mute_monitor).once.with(12345)
-      subject.mute_monitor_by_id(12345)
+      expect(dog).to receive(:mute_monitor).once.with(12_345)
+      subject.mute_monitor_by_id(12_345)
     end
     it 'calls dog.mute_monitor with id and timestamp if specified' do
       dog = double(Dogapi::Client)
@@ -1012,15 +1012,13 @@ describe DogTrainer::API do
       subject.instance_variable_set('@dog', dog)
 
       expect(dog).to receive(:mute_monitor).once
-        .with(12345, {end: 6789})
-      subject.mute_monitor_by_id(12345, end_timestamp: 6789)
+        .with(12_345, end: 6_789)
+      subject.mute_monitor_by_id(12_345, end_timestamp: 6_789)
     end
   end
   describe '#mute_monitor_by_name' do
     it 'calls dog.mute_monitor with id' do
-      monitor = {
-        'id' => 5678,
-      }
+      monitor = { 'id' => 5_678 }
       dog = double(Dogapi::Client)
       allow(dog).to receive(:mute_monitor).with(any_args)
       allow(subject).to receive(:get_existing_monitor_by_name)
@@ -1029,13 +1027,11 @@ describe DogTrainer::API do
 
       expect(subject).to receive(:get_existing_monitor_by_name).once
         .with('mymon')
-      expect(dog).to receive(:mute_monitor).once.with(5678)
+      expect(dog).to receive(:mute_monitor).once.with(5_678)
       subject.mute_monitor_by_name('mymon')
     end
     it 'calls dog.mute_monitor with id and timestamp if specified' do
-      monitor = {
-        'id' => 5678,
-      }
+      monitor = { 'id' => 5_678 }
       dog = double(Dogapi::Client)
       allow(dog).to receive(:mute_monitor).with(any_args)
       allow(subject).to receive(:get_existing_monitor_by_name)
@@ -1044,8 +1040,8 @@ describe DogTrainer::API do
 
       expect(subject).to receive(:get_existing_monitor_by_name).once
         .with('mymon')
-      expect(dog).to receive(:mute_monitor).once.with(5678, {end: 1234})
-      subject.mute_monitor_by_name('mymon', end_timestamp: 1234)
+      expect(dog).to receive(:mute_monitor).once.with(5_678, end: 1_234)
+      subject.mute_monitor_by_name('mymon', end_timestamp: 1_234)
     end
     it 'raises error if monitor cannot be found' do
       dog = double(Dogapi::Client)
@@ -1065,10 +1061,10 @@ describe DogTrainer::API do
   describe '#mute_monitors_by_regex' do
     it 'mutes all matching monitors when passed a regex' do
       monitors = [
-        {'name' => 'mymonitor', 'id' => 1},
-        {'name' => 'foo', 'id' => 2},
-        {'name' => 'bar', 'id' => 3},
-        {'name' => 'other monitor foo', 'id' => 4}
+        { 'name' => 'mymonitor', 'id' => 1 },
+        { 'name' => 'foo', 'id' => 2 },
+        { 'name' => 'bar', 'id' => 3 },
+        { 'name' => 'other monitor foo', 'id' => 4 }
       ]
       allow(subject).to receive(:get_monitors).and_return(monitors)
       allow(subject).to receive(:mute_monitor_by_id)
@@ -1082,10 +1078,10 @@ describe DogTrainer::API do
     end
     it 'mutes all matching monitors when passed a string' do
       monitors = [
-        {'name' => 'mymonitor', 'id' => 1},
-        {'name' => 'foo', 'id' => 2},
-        {'name' => 'bar', 'id' => 3},
-        {'name' => 'other monitor foo', 'id' => 4}
+        { 'name' => 'mymonitor', 'id' => 1 },
+        { 'name' => 'foo', 'id' => 2 },
+        { 'name' => 'bar', 'id' => 3 },
+        { 'name' => 'other monitor foo', 'id' => 4 }
       ]
       allow(subject).to receive(:get_monitors).and_return(monitors)
       allow(subject).to receive(:mute_monitor_by_id)
@@ -1099,25 +1095,25 @@ describe DogTrainer::API do
     end
     it 'mutes all monitors with an end_timestamp if specified' do
       monitors = [
-        {'name' => 'mymonitor', 'id' => 1},
-        {'name' => 'foo', 'id' => 2},
-        {'name' => 'bar', 'id' => 3},
-        {'name' => 'other monitor foo', 'id' => 4}
+        { 'name' => 'mymonitor', 'id' => 1 },
+        { 'name' => 'foo', 'id' => 2 },
+        { 'name' => 'bar', 'id' => 3 },
+        { 'name' => 'other monitor foo', 'id' => 4 }
       ]
       allow(subject).to receive(:get_monitors).and_return(monitors)
       allow(subject).to receive(:mute_monitor_by_id)
 
       expect(subject).to receive(:get_monitors).once
       expect(subject).to receive(:mute_monitor_by_id).once
-        .with(1, end_timestamp: 1234)
+        .with(1, end_timestamp: 1_234)
       expect(subject).to receive(:mute_monitor_by_id).once
-        .with(4, end_timestamp: 1234)
-      subject.mute_monitors_by_regex('monitor', end_timestamp: 1234)
+        .with(4, end_timestamp: 1_234)
+      subject.mute_monitors_by_regex('monitor', end_timestamp: 1_234)
     end
     it 'does not mute any monitors if there are no matches' do
       monitors = [
-        {'name' => 'foo', 'id' => 2},
-        {'name' => 'bar', 'id' => 3}
+        { 'name' => 'foo', 'id' => 2 },
+        { 'name' => 'bar', 'id' => 3 }
       ]
       allow(subject).to receive(:get_monitors).and_return(monitors)
       allow(subject).to receive(:mute_monitor_by_id)
@@ -1134,15 +1130,13 @@ describe DogTrainer::API do
       subject.instance_variable_set('@dog', dog)
 
       expect(dog).to receive(:unmute_monitor).once
-        .with(12345, {:all_scopes=>true})
-      subject.unmute_monitor_by_id(12345)
+        .with(12_345, all_scopes: true)
+      subject.unmute_monitor_by_id(12_345)
     end
   end
   describe '#unmute_monitor_by_name' do
     it 'calls dog.unmute_monitor with id' do
-      monitor = {
-        'id' => 5678,
-      }
+      monitor = { 'id' => 5_678 }
       allow(subject).to receive(:unmute_monitor_by_id).with(any_args)
       allow(subject).to receive(:get_existing_monitor_by_name)
         .and_return(monitor)
@@ -1150,7 +1144,7 @@ describe DogTrainer::API do
       expect(subject).to receive(:get_existing_monitor_by_name).once
         .with('mymon')
       expect(subject).to receive(:unmute_monitor_by_id).once
-        .with(5678)
+        .with(5_678)
       subject.unmute_monitor_by_name('mymon')
     end
     it 'raises error if monitor cannot be found' do
@@ -1169,10 +1163,10 @@ describe DogTrainer::API do
   describe '#unmute_monitors_by_regex' do
     it 'unmutes all matching monitors when passed a regex' do
       monitors = [
-        {'name' => 'mymonitor', 'id' => 1},
-        {'name' => 'foo', 'id' => 2},
-        {'name' => 'bar', 'id' => 3},
-        {'name' => 'other monitor foo', 'id' => 4}
+        { 'name' => 'mymonitor', 'id' => 1 },
+        { 'name' => 'foo', 'id' => 2 },
+        { 'name' => 'bar', 'id' => 3 },
+        { 'name' => 'other monitor foo', 'id' => 4 }
       ]
       allow(subject).to receive(:get_monitors).and_return(monitors)
       allow(subject).to receive(:unmute_monitor_by_id)
@@ -1184,10 +1178,10 @@ describe DogTrainer::API do
     end
     it 'unmutes all matching monitors when passed a string' do
       monitors = [
-        {'name' => 'mymonitor', 'id' => 1},
-        {'name' => 'foo', 'id' => 2},
-        {'name' => 'bar', 'id' => 3},
-        {'name' => 'other monitor foo', 'id' => 4}
+        { 'name' => 'mymonitor', 'id' => 1 },
+        { 'name' => 'foo', 'id' => 2 },
+        { 'name' => 'bar', 'id' => 3 },
+        { 'name' => 'other monitor foo', 'id' => 4 }
       ]
       allow(subject).to receive(:get_monitors).and_return(monitors)
       allow(subject).to receive(:unmute_monitor_by_id)
@@ -1199,8 +1193,8 @@ describe DogTrainer::API do
     end
     it 'does not unmute any monitors if there are no matches' do
       monitors = [
-        {'name' => 'foo', 'id' => 2},
-        {'name' => 'bar', 'id' => 3}
+        { 'name' => 'foo', 'id' => 2 },
+        { 'name' => 'bar', 'id' => 3 }
       ]
       allow(subject).to receive(:get_monitors).and_return(monitors)
       allow(subject).to receive(:unmute_monitor_by_id)
@@ -1227,7 +1221,6 @@ describe DogTrainer::API do
     end
     it 'returns nil if no monitors can be found' do
       monitors = ['200', []]
-      dog = double(Dogapi::Client)
       allow(subject).to receive(:get_monitors).and_return(monitors[1])
 
       expect(subject).to receive(:get_monitors).once


### PR DESCRIPTION
Adds support for muting and unmuting monitors based on ID, Name, or regex matching monitor name. Includes support for muting until a specified time.

100% test coverage, and all branches manually tested against DataDog API.
