### PR TITLE
0.4.1 - update cri, rubocop and yard development dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,5 @@
-#Lint/UselessAssignment:
-#  Exclude:
-#    - 'lib/dogtrainer/api.rb'
-#    - 'spec/unit/api_spec.rb'
+AllCops:
+  TargetRubyVersion: 2.0
 
 Metrics/AbcSize:
   Max: 100

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+Version 0.4.1
+
+  - Upgrade rubocop and yard development dependency versions
+  - Pin `cri` development dependency to 2.9 to retain ruby 2.0 support
+
 Version 0.4.0
 
   - Added support for ``:no_data_timeframe`` and ``:evaluation_delay`` options

--- a/dogtrainer.gemspec
+++ b/dogtrainer.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rb-readline', '~> 0.5'
 
   gem.add_development_dependency 'bundler'
-  gem.add_development_dependency 'cri', '~> 2'
+  gem.add_development_dependency 'cri', '~> 2.9.1'
   gem.add_development_dependency 'diplomat', '~> 0.15'
   gem.add_development_dependency 'faraday', '~> 0.9'
   gem.add_development_dependency 'ghpages_deploy', '~> 1.3'
@@ -40,10 +40,10 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'retries', '~> 0.0.5'
   gem.add_development_dependency 'rspec', '~> 3'
   gem.add_development_dependency 'rspec_junit_formatter', '~> 0.2'
-  gem.add_development_dependency 'rubocop', '~> 0.37'
+  gem.add_development_dependency 'rubocop', '~> 0.49.1'
   gem.add_development_dependency 'simplecov', '~> 0.11'
   gem.add_development_dependency 'simplecov-console'
-  gem.add_development_dependency 'yard', '~> 0.8'
+  gem.add_development_dependency 'yard', '~> 0.9.11'
 
   # ensure gem will only push to our Artifactory
   # this requires rubygems >= 2.2.0

--- a/lib/dogtrainer/version.rb
+++ b/lib/dogtrainer/version.rb
@@ -1,4 +1,4 @@
 module DogTrainer
   # store the verson of the Gem/module; used in the gemspec and in messages
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end


### PR DESCRIPTION
GitHub's [Network dependencies](https://github.com/manheim/tfwrapper/network/dependencies) shows that this project has two dependencies with open CVEs, rubocop and yard. Both are development dependencies and only executed during tests, so there shouldn't be any real risk, but it's probably good to upgrade them to non-vulnerable versions.

We needed a minor change to `.rubocop.yml` to work around changes introduced by the upgrade.